### PR TITLE
feat: Enhance contribution guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,40 @@
-# Matomo-Icons
+# Matomo Icons
 
 [![Build Status](https://api.travis-ci.com/matomo-org/matomo-icons.svg?branch=master)](https://travis-ci.com/matomo-org/matomo-icons)
 
-This reposistory provides the source files for the icons in [matomo](https://github.com/matomo-org/matomo) and the scripts used to resize them to a common size.
+This repository provides the source files for the icons in [Matomo](https://github.com/matomo-org/matomo) and the scripts used to convert them into a unified format.
 
 ## Contributing
 
-An icon is missing or you have a better one? Create a [new issue](https://github.com/matomo-org/matomo-icons/issues/new) or, even better, open a pull request.
-You can find a up-to-date list of all improvable icons on [Travis](https://app.travis-ci.com/github/matomo-org/matomo-icons).
+An icon is missing, or you have a better one? Create a [new issue](https://github.com/matomo-org/matomo-icons/issues/new) or, even better, open a pull request.
 
-All source files except those in `devices`, `flags`, `searchEngines` and `socials` need to have a second file called `iconname.ext.source` that mentions where the image is from.
+🖌️ Hint: We regularly generate a [list of improvable icons](https://app.travis-ci.com/github/matomo-org/matomo-icons). Some may have the wrong source file format, some may be too small. Feel free to pick one or two and provide a PR for it.
 
-### Naming conventions
-
-| icon type | example | possible names |
-| --------- | ------- | ----------- |
-|brand|*Apple*| *Device detection* in Matomo Administration page|
-|browsers|*FF*|https://github.com/matomo-org/device-detector/blob/master/Parser/Client/Browser.php#L37 |
-|devices|*smartphone*| *Device detection* in Matomo Administration page|
-|flags|*at*| all except *un* and *gb-** |
-|os|*WIN*|https://github.com/matomo-org/device-detector/blob/master/Parser/OperatingSystem.php#L38 |
-|plugins|*flash*|files in [plugins/DevicePlugins/Columns/](https://github.com/matomo-org/matomo/tree/4.x-dev/plugins/DevicePlugins/Columns) |
-|searchEngines|*google.com*|https://github.com/matomo-org/searchengine-and-social-list/blob/master/SearchEngines.yml |
-|SEO|*bing.com*|https://github.com/matomo-org/matomo/tree/4.x-dev/plugins/SEO |
-|socials|*facebook.com*|https://github.com/matomo-org/searchengine-and-social-list/blob/master/Socials.yml |
+All source files are stored in categorized subfolders in `/src`.
+Please check whether your icon proposal complies with the following conventions. Then run the `convert.sh` script once to update the icon build in the `/dist` folder.
 
 ### File Formats
 
-Ideally all source files should be SVGs or high resolution (>100px) PNGs. As this is not always possible, JPGs, GIFs and (even multiresolution) ICOs are supported.
+Ideally all source files should be SVGs or high resolution (> 100px) PNGs.
+
+As this is not always possible, JPGs, GIFs and (even multi resolution) ICOs are supported as well.
+
+### Naming
+
+The grouping and naming of all icons results from the data sets that Matomo uses in its own tracking analysis.
+
+| Icon category   | Data source for naming                                                                             | Example                      |
+|-----------------|----------------------------------------------------------------------------------------------------|------------------------------|
+| `brand`         | *Device detection* in Matomo Administration page                                                   | `Apple.png`                  |
+| `browsers`      | https://github.com/matomo-org/device-detector/blob/master/Parser/Client/Browser.php                | `FF.png` for Firefox Browser |
+| `devices`       | https://github.com/matomo-org/matomo/blob/5.x-dev/plugins/DevicesDetection/functions.php#L183-L198 | `smartphone.png`             |
+| `flags`         | https://github.com/lipis/flag-icons/tree/main/flags/4x3                                            | `at.png` for Austria         |
+| `os`            | https://github.com/matomo-org/device-detector/blob/master/Parser/OperatingSystem.php#L38           | `WIN.png` for Windows        |
+| `plugins`       | https://github.com/matomo-org/matomo/tree/5.x-dev/plugins/DevicePlugins/Columns                    | `flash.png`                  |
+| `searchEngines` | https://github.com/matomo-org/searchengine-and-social-list/blob/master/SearchEngines.yml           | `google.com.png`             |
+| `SEO`           | https://github.com/matomo-org/matomo/tree/5.x-dev/plugins/SEO                                      | `bing.com.png`               |
+| `socials`       | https://github.com/matomo-org/searchengine-and-social-list/blob/master/Socials.yml                 | `facebook.com.png`           |
+
+### Attribution
+
+Every source file, except those in `devices`, `flags`, `searchEngines` and `socials`, needs to have a second file according to the scheme `<icon name>.<file extension>.source` that mentions where the image is from.


### PR DESCRIPTION
During make of PR 33 I noticed that the README could need some improvements.

Added missing steps (explain that you have to use the convert script to contribute),
explain conventions, improve the clarity of the text, update links in naming scheme table
(still point to Matomo 4).

Rendered example: https://github.com/pixelbrackets/matomo-icons/blob/20240604-improve-readme/README.md

