### PR TITLE
Add icon for Vivaldi Mobile iOS

### DIFF
--- a/src/browsers/V7.png
+++ b/src/browsers/V7.png
@@ -1,0 +1,1 @@
+../../node_modules/browser-logos/src/vivaldi/vivaldi.png


### PR DESCRIPTION
Adds a new symlink to the `vivaldi.png` file to correspond with the `V7` code for Vivaldi Mobile iOS added in https://github.com/matomo-org/device-detector/pull/8261